### PR TITLE
Updated email param

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -58,7 +58,7 @@ class Provider extends AbstractProvider implements ProviderInterface
             'id' => $user['id'],
             'nickname' => $user['display_name'],
             'name' => $user['id'],
-            'email' => null,
+            'email' => isset($user['email']) ? $user['email'] : null,
             'avatar' => array_get($user, 'images.0.url'),
         ]);
     }


### PR DESCRIPTION
Spotify will return an email address if the user-read-email scope is specified. Added this to the Socialite user object.
